### PR TITLE
update copyrights (#22)

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -19,4 +19,5 @@ jobs:
       with:
         globs: |
           **/*.md
+          !SECURITY.md
           !.github/**/*.md

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,63 +1,34 @@
-# Security
-
-```{=html}
 <!-- BEGIN MICROSOFT SECURITY.MD V0.0.9 BLOCK -->
-```
 
-Microsoft takes the security of our software products and services
-seriously, which includes all source code repositories managed through
-our GitHub organizations, which include
-[Microsoft](https://github.com/Microsoft),
-[Azure](https://github.com/Azure), [DotNet](https://github.com/dotnet),
-[AspNet](https://github.com/aspnet) and
-[Xamarin](https://github.com/xamarin).
+## Security
 
-If you believe you have found a security vulnerability in any
-Microsoft-owned repository that meets [Microsoft's definition of a
-security vulnerability](https://aka.ms/security.md/definition), please
-report it to us as described below.
+Microsoft takes the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations, which include [Microsoft](https://github.com/Microsoft), [Azure](https://github.com/Azure), [DotNet](https://github.com/dotnet), [AspNet](https://github.com/aspnet) and [Xamarin](https://github.com/xamarin).
+
+If you believe you have found a security vulnerability in any Microsoft-owned repository that meets [Microsoft's definition of a security vulnerability](https://aka.ms/security.md/definition), please report it to us as described below.
 
 ## Reporting Security Issues
 
-**Please do not report security vulnerabilities through public GitHub
-issues.**
+**Please do not report security vulnerabilities through public GitHub issues.**
 
-Instead, please report them to the Microsoft Security Response Center
-(MSRC) at
-[https://msrc.microsoft.com/create-report](https://aka.ms/security.md/msrc/create-report).
+Instead, please report them to the Microsoft Security Response Center (MSRC) at [https://msrc.microsoft.com/create-report](https://aka.ms/security.md/msrc/create-report).
 
-If you prefer to submit without logging in, send email to
-<secure@microsoft.com>. If possible, encrypt your message with our PGP
-key; please download it from the [Microsoft Security Response Center PGP
-Key page](https://aka.ms/security.md/msrc/pgp).
+If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the [Microsoft Security Response Center PGP Key page](https://aka.ms/security.md/msrc/pgp).
 
-You should receive a response within 24 hours. If for some reason you do
-not, please follow up via email to ensure we received your original
-message. Additional information can be found at
-[microsoft.com/msrc](https://www.microsoft.com/msrc).
+You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://www.microsoft.com/msrc).
 
-Please include the requested information listed below (as much as you
-can provide) to help us better understand the nature and scope of the
-possible issue:
+Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
 
-- Type of issue (e.g.buffer overflow, SQL injection, cross-site
-    scripting, etc.)
-- Full paths of source file(s) related to the manifestation of the
-    issue
-- The location of the affected source code (tag/branch/commit or
-    direct URL)
-- Any special configuration required to reproduce the issue
-- Step-by-step instructions to reproduce the issue
-- Proof-of-concept or exploit code (if possible)
-- Impact of the issue, including how an attacker might exploit the
-    issue
+  * Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
+  * Full paths of source file(s) related to the manifestation of the issue
+  * The location of the affected source code (tag/branch/commit or direct URL)
+  * Any special configuration required to reproduce the issue
+  * Step-by-step instructions to reproduce the issue
+  * Proof-of-concept or exploit code (if possible)
+  * Impact of the issue, including how an attacker might exploit the issue
 
 This information will help us triage your report more quickly.
 
-If you are reporting for a bug bounty, more complete reports can
-contribute to a higher bounty award. Please visit our [Microsoft Bug
-Bounty Program](https://aka.ms/security.md/msrc/bounty) page for more
-details about our active programs.
+If you are reporting for a bug bounty, more complete reports can contribute to a higher bounty award. Please visit our [Microsoft Bug Bounty Program](https://aka.ms/security.md/msrc/bounty) page for more details about our active programs.
 
 ## Preferred Languages
 
@@ -65,9 +36,6 @@ We prefer all communications to be in English.
 
 ## Policy
 
-Microsoft follows the principle of [Coordinated Vulnerability
-Disclosure](https://aka.ms/security.md/cvd).
+Microsoft follows the principle of [Coordinated Vulnerability Disclosure](https://aka.ms/security.md/cvd).
 
-```{=html}
 <!-- END MICROSOFT SECURITY.MD BLOCK -->
-```

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,21 +1,5 @@
 # Support
 
-**REPO OWNER**: Do you want Customer Service & Support (CSS) support for
-this product/project?
-
-- **No CSS support:** Fill out this template with information about
-    how to file issues and get help.
-
-- **Yes CSS support:** Fill out an intake form at
-    [aka.ms/onboardsupport](https://aka.ms/onboardsupport). CSS will
-    work with/help you to determine next steps.
-
-- **Not sure?** Fill out an intake as though the answer were "Yes".
-    CSS will help you decide.
-
-*Then remove this first heading from this SUPPORT.MD file before
-publishing your repo.*
-
 ## How to file issues and get help
 
 This project uses GitHub Issues to track bugs and feature requests.
@@ -23,10 +7,7 @@ Please search the existing issues before filing new issues to avoid
 duplicates. For new issues, file your bug or feature request as a new
 Issue.
 
-For help and questions about using this project, please **REPO
-MAINTAINER: INSERT INSTRUCTIONS HERE FOR HOW TO ENGAGE REPO OWNERS OR
-COMMUNITY FOR HELP. COULD BE A STACK OVERFLOW TAG OR OTHER CHANNEL.
-WHERE WILL YOU HELP PEOPLE?**.
+For help and questions about using this project, please create a Pull Request, or file a [Github Issue](https://github.com/microsoft/DynamicTelemetry/issues).
 
 ## Microsoft Support Policy
 

--- a/docs/Graphics/Banner.Template.html
+++ b/docs/Graphics/Banner.Template.html
@@ -1,3 +1,6 @@
+<!-- Copyright (c) Microsoft Corporation.
+Licensed under the MIT License. -->
+
 <!DOCTYPE html>
 <html>
 <head>

--- a/docs/LookoutTower/Samples/FileExtensionStats/Sample.FileExtensionStats.cs
+++ b/docs/LookoutTower/Samples/FileExtensionStats/Sample.FileExtensionStats.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //start
 using Microsoft.Extensions.Logging;
 using System.Security.Cryptography;

--- a/docs/LookoutTower/Samples/TriggeringOnQueue/TriggeringOnQueue.cs
+++ b/docs/LookoutTower/Samples/TriggeringOnQueue/TriggeringOnQueue.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //start
 using Microsoft.Extensions.Logging;
 using System.Security.Cryptography;

--- a/docs/Samples/Demo1-Introduction/DynamicTelemetry-Demo1-Introduction/Pages/Index.cshtml
+++ b/docs/Samples/Demo1-Introduction/DynamicTelemetry-Demo1-Introduction/Pages/Index.cshtml
@@ -1,4 +1,7 @@
-﻿@page
+﻿<!-- Copyright (c) Microsoft Corporation.
+ Licensed under the MIT License. -->
+
+@page
 @model IndexModel
 
 <html lang="en">

--- a/docs/Samples/Demo1-Introduction/DynamicTelemetry-Demo1-Introduction/Pages/Index.cshtml.cs
+++ b/docs/Samples/Demo1-Introduction/DynamicTelemetry-Demo1-Introduction/Pages/Index.cshtml.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using System.Diagnostics.Metrics;
 

--- a/docs/Samples/Demo1-Introduction/DynamicTelemetry-Demo1-Introduction/Pages/_ViewImports.cshtml
+++ b/docs/Samples/Demo1-Introduction/DynamicTelemetry-Demo1-Introduction/Pages/_ViewImports.cshtml
@@ -1,3 +1,6 @@
-﻿@using DynamicTelemetry_Demo1_Introduction
+﻿<!-- Copyright (c) Microsoft Corporation.
+ Licensed under the MIT License. -->
+
+@using DynamicTelemetry_Demo1_Introduction
 @namespace OpenTelemetry.ImageTracker.Pages
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/docs/Samples/Demo1-Introduction/DynamicTelemetry-Demo1-Introduction/Program.cs
+++ b/docs/Samples/Demo1-Introduction/DynamicTelemetry-Demo1-Introduction/Program.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using Azure.Identity;
 using Azure.Monitor.OpenTelemetry.AspNetCore;
 using System.Diagnostics;

--- a/docs/Samples/Demos.3.SecurityRedaction/Pages/Index.cshtml
+++ b/docs/Samples/Demos.3.SecurityRedaction/Pages/Index.cshtml
@@ -1,4 +1,7 @@
-﻿@page
+﻿<!-- Copyright (c) Microsoft Corporation.
+ Licensed under the MIT License. -->
+
+@page
 @model IndexModel
 
 <html lang="en">

--- a/docs/Samples/Demos.3.SecurityRedaction/Pages/Index.cshtml.cs
+++ b/docs/Samples/Demos.3.SecurityRedaction/Pages/Index.cshtml.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // StartExample:RedactSecret
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using System.Diagnostics.Metrics;

--- a/docs/Samples/Demos.3.SecurityRedaction/Pages/_ViewImports.cshtml
+++ b/docs/Samples/Demos.3.SecurityRedaction/Pages/_ViewImports.cshtml
@@ -1,3 +1,6 @@
-﻿@using DynamicTelemetry_Demo_3_SecurityRedactions
+﻿<!-- Copyright (c) Microsoft Corporation.
+ Licensed under the MIT License. -->
+
+@using DynamicTelemetry_Demo_3_SecurityRedactions
 @namespace DynamicTelemetry_Demo_3_SecurityRedactions.Pages
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/docs/Samples/Demos.3.SecurityRedaction/Program.cs
+++ b/docs/Samples/Demos.3.SecurityRedaction/Program.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using Azure.Identity;
 using Azure.Monitor.OpenTelemetry.AspNetCore;
 using System.Diagnostics;

--- a/docs/Samples/Demos.4.InsertTelemetry/Pages/Index.cshtml
+++ b/docs/Samples/Demos.4.InsertTelemetry/Pages/Index.cshtml
@@ -1,4 +1,7 @@
-﻿@page
+﻿<!-- Copyright (c) Microsoft Corporation.
+ Licensed under the MIT License. -->
+
+@page
 @model IndexModel
 
 <html lang="en">

--- a/docs/Samples/Demos.4.InsertTelemetry/Pages/Index.cshtml.cs
+++ b/docs/Samples/Demos.4.InsertTelemetry/Pages/Index.cshtml.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // StartExample:InsertTelemetry
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Caching.Memory;

--- a/docs/Samples/Demos.4.InsertTelemetry/Pages/_ViewImports.cshtml
+++ b/docs/Samples/Demos.4.InsertTelemetry/Pages/_ViewImports.cshtml
@@ -1,3 +1,6 @@
-﻿@using DynamicTelemetry_Demo_3_SecurityRedactions
+﻿<!-- Copyright (c) Microsoft Corporation.
+ Licensed under the MIT License. -->
+
+@using DynamicTelemetry_Demo_3_SecurityRedactions
 @namespace DynamicTelemetry_Demo_3_SecurityRedactions.Pages
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/docs/Samples/Demos.4.InsertTelemetry/Program.cs
+++ b/docs/Samples/Demos.4.InsertTelemetry/Program.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using Azure.Identity;
 using Azure.Monitor.OpenTelemetry.AspNetCore;
 using System.Diagnostics;

--- a/docs/Samples/DurableIds/Pages/Index.cshtml
+++ b/docs/Samples/DurableIds/Pages/Index.cshtml
@@ -1,4 +1,7 @@
-﻿@page
+﻿<!-- Copyright (c) Microsoft Corporation.
+ Licensed under the MIT License. -->
+
+@page
 @model IndexModel
 
 <html lang="en">

--- a/docs/Samples/DurableIds/Pages/Index.cshtml.cs
+++ b/docs/Samples/DurableIds/Pages/Index.cshtml.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // StartExample:ContrastDurableID
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using System.Diagnostics.Metrics;

--- a/docs/Samples/DurableIds/Pages/_ViewImports.cshtml
+++ b/docs/Samples/DurableIds/Pages/_ViewImports.cshtml
@@ -1,3 +1,6 @@
-﻿@using DynamicTelemetry_Demo_DurableIds
+﻿<!-- Copyright (c) Microsoft Corporation.
+ Licensed under the MIT License. -->
+
+@using DynamicTelemetry_Demo_DurableIds
 @namespace DynamicTelemetry_Demo_DurableIds.Pages
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/docs/Samples/DurableIds/Program.cs
+++ b/docs/Samples/DurableIds/Program.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using Azure.Identity;
 using Azure.Monitor.OpenTelemetry.AspNetCore;
 using System.Diagnostics;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -188,7 +188,7 @@ nav:
             - Data Ownership isnt always Clear: ./docs/PositionPaper.DataOwnershipIsntAlwaysClear.document.md
             - Logs into Metrics: ./docs/PositionPaper.ConvertLogsToMetrics.document.md
             - Triggered Collections: ./docs/PositionPaper.TriggeredCollections.document.md
-            - Proceduralize Nets: ./docs/PositionPaper.ProceduralizeNets.document.md
+            - Procedural Nets: ./docs/PositionPaper.ProceduralizeNets.document.md
             - Locks and Throttles: ./docs/PositionPaper.LeafLevelLogging.document.md
             - Loose Schemas: ./docs/PositionPaper.SharingDataAmongStakeHoldersIsHard.document.md
         - Demo Videos:
@@ -322,15 +322,12 @@ extra:
         value: Testing1234
         checked: true
 
-
   analytics:
     provider: custom
     actions:
       - accept
       - reject
       - manage
-
-
 
 extra_css:
     - extra.css

--- a/overrides/partials/integrations/analytics/custom.html
+++ b/overrides/partials/integrations/analytics/custom.html
@@ -1,3 +1,6 @@
+<!-- Copyright (c) Microsoft Corporation.
+Licensed under the MIT License. -->
+
 <script>
     /* Add custom analytics integration here, e.g. */
     var property = "{{ config.extra.analytics.property }}"


### PR DESCRIPTION
This change applies a few copyright and lint changes that came in after the source snap a few days ago.

Notice that the main branch is now a squash of >100 commits, from a few months.  The history is cleaned up.