### PR TITLE
fix spelling mistake in demo

### DIFF
--- a/docs/Samples/DurableIds/Pages/Index.cshtml.cs
+++ b/docs/Samples/DurableIds/Pages/Index.cshtml.cs
@@ -42,13 +42,13 @@ namespace DynamicTelemetry_Demo_DurableIds.Pages
             //
             // Log a message without a DurableID;  while simple, this log will provide struggles later
             //    because while we receive a property bag of the variables (_version), we will not know
-            //    which line of code emitted the telemetry - as our only identtifer will be the
+            //    which line of code emitted the telemetry - as our only identifier will be the
             //    'flattened' payload string
             //
             // NOTE: adding the _instanceID is to showcase how, once 'flattened' this unrecommendable
             //    method of logging makes for tricky (and expensive) backend searching
             //
-            _logger.LogInformation($"Launch, ver={_version}, instantion={_instanceID}");
+            _logger.LogInformation($"Launch, ver={_version}, instanceID={_instanceID}");
         }
         // EndExample:NoDurableId
 
@@ -73,8 +73,8 @@ namespace DynamicTelemetry_Demo_DurableIds.Pages
             LogLaunch(_logger, _version, _instanceID);
         }
 
-        [LoggerMessage(Level = LogLevel.Information, Message = "Launch, ver={version}, instantion={instantionID}")]
-        static partial void LogLaunch(ILogger logger, string version, Guid instantionID);
+        [LoggerMessage(Level = LogLevel.Information, Message = "Launch, ver={version}, instanceID={instanceID}")]
+        static partial void LogLaunch(ILogger logger, string version, Guid instanceID);
         // EndExample:DurableId
 
 


### PR DESCRIPTION
This pull request makes minor corrections to logging code in `docs/Samples/DurableIds/Pages/Index.cshtml.cs` to fix typos and improve consistency in variable naming.

### Typo Fixes and Variable Naming Consistency:
* Corrected the misspelling of "instantion" to "instanceID" in both the log message and variable name within the `LogWithoutDurableID` method.
* Updated the `LogWithDurableID` method to fix the same typo in the log message and align the variable name from "instantionID" to "instanceID" for consistency.Fixes #
Design discussion issue #

## Changes

Please provide a brief description of the changes here.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/microsoft/DynamicTelemetry/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Unit tests added/updated (if applicable).
