### PR TITLE
delete forgotten (and failing) publish of a .zip file, that doesnt exist

### DIFF
--- a/.github/workflows/buildbundles.yml
+++ b/.github/workflows/buildbundles.yml
@@ -70,17 +70,6 @@ jobs:
           draft: false
           prerelease: ${{ !startsWith(github.ref, 'refs/tags/v') }}
 
-      - name: Upload DOCX files
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./release-files
-          asset_name: documentation-bundle-docx.zip
-          asset_content_type: application/zip
-        continue-on-error: true
-
       - name: Upload all release files
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
This pull request simplifies the release asset upload process in the GitHub Actions workflow by consolidating the upload steps.

Release workflow simplification:

* Removed the separate "Upload DOCX files" step that used `actions/upload-release-asset@v1`, and now all release files are uploaded in a single step using `softprops/action-gh-release@v1` in `.github/workflows/buildbundles.yml`.Fixes #
Design discussion issue #

## Changes

Please provide a brief description of the changes here.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/microsoft/DynamicTelemetry/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Unit tests added/updated (if applicable).
